### PR TITLE
Close #89 through bucketing and rounding

### DIFF
--- a/app/Model/Position.php
+++ b/app/Model/Position.php
@@ -126,11 +126,11 @@ class Model_Position extends Model
     /**
      * returns the vatpercentage.
      *
-     * @return float
+     * @return string
      */
-    public function getVatPercentage(): float
+    public function getVatPercentage()
     {
-        return (float)$this->bean->vatpercentage;
+        return $this->bean->vatpercentage;
     }
 
     /**


### PR DESCRIPTION
To fix #89 transaction calcSums now collects the totals of each position according to its vat percentage and rounds those at the end. Then the vat amount is calculated for the (sub)-sums.